### PR TITLE
fixed wrong restclient dep version on TCK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <java-hamcrest.version>2.0.0.0</java-hamcrest.version>
         <httpclient.version>4.5.2</httpclient.version>
         <jackson.version>2.10.1</jackson.version>
-        <restclient.version>2.0</restclient.version>
+        <restclient.version>2.0-RC3</restclient.version>
 
         <!-- Versions of SPEC dependencies  -->
         <asciidoctor-maven.version>1.6.0</asciidoctor-maven.version>


### PR DESCRIPTION
fixing the build due to the wrong TCK dependency version, replacing to the most recent version 2.0-RC3

Error:  Failed to execute goal on project microprofile-openapi-tck: Could not resolve dependencies for project org.eclipse.microprofile.openapi:microprofile-openapi-tck:jar:2.0-SNAPSHOT: Could not find artifact org.eclipse.microprofile.rest.client:microprofile-rest-client-api:jar:2.0 in central (https://repo.maven.apache.org/maven2) -> [Help 1]
Error:  
Error:  To see the full stack trace of the errors, re-run Maven with the -e switch.
Error:  Re-run Maven using the -X switch to enable full debug logging.
Error:  
Error:  For more information about the errors and possible solutions, please read the following articles:
Error:  [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/DependencyResolutionException
Error:  
Error:  After correcting the problems, you can resume the build with the command
Error:    mvn <args> -rf :microprofile-openapi-tck
Error: Process completed with exit code 1.